### PR TITLE
fix(ci): format run-electron-vite so verify prettier check passes

### DIFF
--- a/scripts/run-electron-vite.mjs
+++ b/scripts/run-electron-vite.mjs
@@ -20,7 +20,11 @@ const requireFrom = (dir) => createRequire(join(dir, 'package.json'))
 function resolveElectronViteCli() {
   for (const dir of [process.cwd(), root]) {
     try {
-      return join(dirname(requireFrom(dir).resolve('electron-vite/package.json')), 'bin', 'electron-vite.js')
+      return join(
+        dirname(requireFrom(dir).resolve('electron-vite/package.json')),
+        'bin',
+        'electron-vite.js'
+      )
     } catch {
       // try the next directory
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What failed

[CI #91](https://github.com/fzlzjerry/ohmyhf/actions/runs/32617898406) on `57a4661` (`fix(dev): launch Electron reliably after incomplete installs`) failed in **verify / Format, lint, typecheck, coverage, build, Ubuntu E2E**.

The failing step was **Check formatting** (`pnpm format:check` / `prettier --check .`). Later verify steps and `packaged-smoke` were skipped because of that exit 1.

```text
Checking formatting...
[warn] scripts/run-electron-vite.mjs
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
```

Reproduced locally on the same commit: only that file fails Prettier. The over-long `join(...)` in `resolveElectronViteCli()` exceeds `printWidth: 100`.

## Fix

Smallest change: wrap that `join()` call so it matches `.prettierrc.json`. No behavior change.

## Local checks

- `pnpm format:check` — pass
- `pnpm lint` — pass
- `pnpm typecheck` — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f79bb8e-deca-4e04-b35d-9f866c267e0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f79bb8e-deca-4e04-b35d-9f866c267e0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

