### PR TITLE
[RELEASE] V0.0.14

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-huggingface-desktop",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "description": "Oh My HuggingFace — unofficial desktop client for the Hugging Face Hub",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-huggingface",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "description": "Unofficial cross-platform desktop client for the Hugging Face Hub",
   "license": "Apache-2.0",

--- a/packages/hub-api/package.json
+++ b/packages/hub-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-my-huggingface/hub-api",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "description": "Pure-TypeScript Hugging Face Hub API client (zero Electron dependencies)",
   "license": "Apache-2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oh-my-huggingface/shared",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "description": "Shared types and typed IPC contract for Oh My HuggingFace",
   "license": "Apache-2.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump all four workspace manifests to **0.0.14** so landing this commit as the head of `main` starts the release workflow.

## What’s in this version
- Opt-out usage telemetry from #20: packaged installs start with telemetry on; users can turn it off from Settings or the first-run card. Existing stored-off preferences and explicit declines stay off.
- Files density, security false-blocks, telemetry status, and Papers reader from #19.

## Release contract
- Manifests: `package.json`, `apps/desktop/package.json`, `packages/shared/package.json`, `packages/hub-api/package.json` are all `0.0.14`.
- Head commit subject is `[RELEASE] V0.0.14`.
- After this is the head of `main`, `.github/workflows/release.yml` will verify, build all three platforms, preflight updater assets, then publish `v0.0.14`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5095bc22-67b9-4dd8-b5e0-860b9a67abad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5095bc22-67b9-4dd8-b5e0-860b9a67abad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

