### PR TITLE
fix: macOS Restart after update now quits and relaunches

### DIFF
--- a/apps/desktop/src/main/downloads.test.ts
+++ b/apps/desktop/src/main/downloads.test.ts
@@ -398,6 +398,40 @@ describe('DownloadManager frozen environment', () => {
     manager.shutdown()
   })
 
+  it('resumes pumping after shutdown so a failed install can continue downloads', async () => {
+    const manager = createManager(new FakeDatabase())
+    await manager.start({ repoId: 'org/repo', kind: 'model', revision: 'main' })
+    const internals = manager as unknown as {
+      shuttingDown: boolean
+      tasks: Map<string, { status: string; files: Array<{ status: string }> }>
+      runtimeAuthTokens: Map<string, string | undefined>
+      latestRevisionTasks: Map<string, { taskId: string }>
+    }
+    const task = [...internals.tasks.values()][0]!
+    const taskId = [...internals.tasks.keys()][0]!
+    task.status = 'running'
+    task.files[0]!.status = 'running'
+
+    manager.shutdown()
+    expect(internals.shuttingDown).toBe(true)
+    expect(internals.runtimeAuthTokens.size).toBe(0)
+    expect(internals.latestRevisionTasks.size).toBe(0)
+
+    await manager.start({ repoId: 'org/other', kind: 'model', revision: 'main' })
+    expect(internals.shuttingDown).toBe(true)
+    expect(manager.list().find((item) => item.repoId === 'org/other')?.status).toBe('queued')
+
+    manager.resumeAfterShutdown()
+    expect(internals.shuttingDown).toBe(false)
+    expect(task.files[0]!.status).toBe('queued')
+    expect(internals.runtimeAuthTokens.get(taskId)).toBe('hf_test')
+    expect(internals.latestRevisionTasks.size).toBeGreaterThan(0)
+
+    const after = await manager.start({ repoId: 'org/third', kind: 'model', revision: 'main' })
+    expect(after.some((item) => item.repoId === 'org/third')).toBe(true)
+    manager.shutdown()
+  })
+
   it('waits for an old worker to exit before pumping an immediate resume', async () => {
     vi.useFakeTimers()
     const db = new FakeDatabase()

--- a/apps/desktop/src/main/downloads.test.ts
+++ b/apps/desktop/src/main/downloads.test.ts
@@ -487,6 +487,62 @@ describe('DownloadManager frozen environment', () => {
     manager.shutdown()
   })
 
+  it('waits for shutdown workers to exit before pumping resumeAfterShutdown', async () => {
+    vi.useFakeTimers()
+    const db = new FakeDatabase()
+    const settings = createSettings()
+    const manager = createManager(db, createHub(), settings)
+    await manager.start({ repoId: 'org/repo', kind: 'model', revision: 'main' })
+    const internals = manager as unknown as {
+      tasks: Map<
+        string,
+        {
+          id: string
+          status: string
+          files: Array<{ path: string; status: string }>
+        }
+      >
+      workers: Map<
+        string,
+        {
+          postMessage: ReturnType<typeof vi.fn>
+          removeAllListeners: ReturnType<typeof vi.fn>
+          terminate: ReturnType<typeof vi.fn>
+        }
+      >
+      stoppingTasks: Map<string, Promise<unknown>>
+    }
+    const task = [...internals.tasks.values()][0]!
+    const file = task.files[0]!
+    task.status = 'running'
+    file.status = 'running'
+    let finishTermination!: () => void
+    const terminated = new Promise<void>((resolve) => {
+      finishTermination = resolve
+    })
+    const worker = {
+      postMessage: vi.fn(),
+      removeAllListeners: vi.fn(),
+      terminate: vi.fn(() => terminated)
+    }
+    internals.workers.set(`${task.id} ${file.path}`, worker)
+    settings.get().downloadConcurrency = 1
+
+    manager.shutdown()
+    manager.resumeAfterShutdown()
+
+    expect(worker.terminate).toHaveBeenCalledOnce()
+    expect(internals.stoppingTasks.has(task.id)).toBe(true)
+    expect(internals.workers.size).toBe(0)
+    expect(file.status).toBe('queued')
+    const stopping = internals.stoppingTasks.get(task.id)!
+    settings.get().downloadConcurrency = 0
+    finishTermination()
+    await stopping
+    expect(internals.stoppingTasks.has(task.id)).toBe(false)
+    manager.shutdown()
+  })
+
   it('publishes the revision ref only after every file completes', async () => {
     vi.useFakeTimers()
     const cacheDir = mkdtempSync(join(tmpdir(), 'omh-download-ref-'))

--- a/apps/desktop/src/main/downloads.ts
+++ b/apps/desktop/src/main/downloads.ts
@@ -1468,13 +1468,11 @@ export class DownloadManager {
       clearTimeout(this.broadcastTimer)
       this.broadcastTimer = null
     }
-    for (const [, worker] of this.workers) {
-      worker.removeAllListeners()
-      worker.postMessage({ type: 'abort' })
-      void worker.terminate()
+    // Track terminate the same way pause/resume does so a later
+    // resumeAfterShutdown cannot spawn a writer onto a still-open blob.
+    for (const task of this.tasks.values()) {
+      void this.abortTaskWorkers(task)
     }
-    this.workers.clear()
-    this.stoppingTasks.clear()
     const idsToFlush = new Set(this.dirtyTaskIds)
     for (const task of this.tasks.values()) {
       if (task.status === 'running' || task.status === 'queued') idsToFlush.add(task.id)

--- a/apps/desktop/src/main/downloads.ts
+++ b/apps/desktop/src/main/downloads.ts
@@ -1484,4 +1484,19 @@ export class DownloadManager {
     this.speedWindow.clear()
     this.latestRevisionTasks.clear()
   }
+
+  /** Undo shutdown after a failed update install so queued work can start again. */
+  resumeAfterShutdown(): void {
+    if (!this.shuttingDown) return
+    this.shuttingDown = false
+    for (const task of this.tasks.values()) {
+      this.rememberRevisionTask(task)
+      if (task.status !== 'queued' && task.status !== 'running') continue
+      for (const file of task.files) {
+        if (file.status === 'running') file.status = 'queued'
+      }
+      this.runtimeAuthTokens.set(task.id, this.getAuthToken())
+    }
+    this.pump()
+  }
 }

--- a/apps/desktop/src/main/follows.test.ts
+++ b/apps/desktop/src/main/follows.test.ts
@@ -94,4 +94,21 @@ describe('FollowsPoller scheduling', () => {
     vi.advanceTimersByTime(10 * 60 * 1000)
     expect(listFollows).toHaveBeenCalledTimes(4)
   })
+
+  it('resumes polling after stop', () => {
+    const { store, set } = makeSettings({ pollIntervalMinutes: 30, notificationsEnabled: true })
+    poller = makePoller(store)
+    poller.start()
+    poller.stop()
+    vi.advanceTimersByTime(30 * 60 * 1000)
+    expect(listFollows).toHaveBeenCalledTimes(1)
+
+    poller.start()
+    expect(listFollows).toHaveBeenCalledTimes(2)
+    set({ notificationsEnabled: false })
+    vi.advanceTimersByTime(29 * 60 * 1000)
+    expect(listFollows).toHaveBeenCalledTimes(2)
+    vi.advanceTimersByTime(60 * 1000)
+    expect(listFollows).toHaveBeenCalledTimes(3)
+  })
 })

--- a/apps/desktop/src/main/follows.ts
+++ b/apps/desktop/src/main/follows.ts
@@ -21,6 +21,7 @@ export class FollowsPoller {
   private polling = false
   /** Interval the running timer was built with, so unrelated settings changes don't reset it. */
   private scheduledMinutes: number | null = null
+  private settingsBound = false
 
   constructor(
     private readonly library: Library,
@@ -34,6 +35,8 @@ export class FollowsPoller {
     this.schedule()
     // First check fires right away; the interval only governs the cadence after it.
     void this.poll()
+    if (this.settingsBound) return
+    this.settingsBound = true
     this.settings.onChange(() => this.schedule())
   }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -148,6 +148,25 @@ if (!gotLock) {
 } else {
   let installingUpdate = false
   let quit: QuitCoordinator | null = null
+  let macInstallRelaunchTimer: ReturnType<typeof setTimeout> | null = null
+
+  const recoverFromFailedInstall = (): void => {
+    if (macInstallRelaunchTimer !== null) {
+      clearTimeout(macInstallRelaunchTimer)
+      macInstallRelaunchTimer = null
+    }
+    installingUpdate = false
+    quit?.reset()
+    const win = BrowserWindow.getAllWindows()[0]
+    if (win && !win.isDestroyed()) {
+      if (win.isMinimized()) win.restore()
+      win.show()
+      win.focus()
+      return
+    }
+    // window-all-closed already skipped quit while installingUpdate was set.
+    recreateWindow?.()
+  }
 
   registerAppProtocol()
 
@@ -450,7 +469,7 @@ if (!gotLock) {
         try {
           await quit?.beginCleanup()
         } catch (error) {
-          installingUpdate = false
+          recoverFromFailedInstall()
           throw error
         }
       },
@@ -458,16 +477,27 @@ if (!gotLock) {
         setImmediate(() => {
           task()
           if (process.platform !== 'darwin') return
-          // Always relaunch if we are still alive: Squirrel may have closed
-          // windows without starting the new process.
+          // quitAndInstall failed (throw or sync 'error'): do not force-relaunch.
+          if (!installingUpdate) return
+          // Squirrel may have closed windows without starting the new process.
           const timer = setTimeout(() => {
+            if (macInstallRelaunchTimer === timer) macInstallRelaunchTimer = null
+            if (!installingUpdate) return
+            // Fallback is only for a windowless handshake, not a visible retry.
+            if (BrowserWindow.getAllWindows().length > 0) return
             app.relaunch()
             app.exit(0)
           }, MAC_INSTALL_RELAUNCH_FALLBACK_MS)
           timer.unref?.()
+          macInstallRelaunchTimer = timer
         })
       },
-      onStateChange: (state) => broadcast('evt:updater', state)
+      onStateChange: (state) => {
+        if (state.status === 'error' && state.operation === 'install') {
+          recoverFromFailedInstall()
+        }
+        broadcast('evt:updater', state)
+      }
     })
 
     const rebuildMenu = (): void => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -38,6 +38,7 @@ import { SecurityGate } from './security-gate'
 import { StarReminderService } from './star-reminder'
 import { applyExplicitTelemetryDecline, DEFAULT_POSTHOG_HOST, TelemetryService } from './telemetry'
 import { TrayManager } from './tray'
+import { QuitCoordinator } from './quit-coordinator'
 import { resolveUpdateClient, UpdateManager } from './updater'
 
 declare const __OMH_POSTHOG_PROJECT_KEY__: string
@@ -80,6 +81,9 @@ const isDev = !app.isPackaged
 // Installs older than the first self-signed release still fall back to manual
 // because their ad-hoc requirement (cdhash-based) can never match.
 const macAutoInstallEnabled = true
+// Squirrel.Mac sometimes only closes windows. After this delay the process
+// relaunches itself so the user is not left with a windowless dock icon.
+const MAC_INSTALL_RELAUNCH_FALLBACK_MS = 8_000
 
 // Renderer crash / load-failure recovery: reload this many times before asking
 // the user, with a short pause so a persistent crash can't spin a tight loop.
@@ -142,7 +146,8 @@ const gotLock = app.isPackaged ? app.requestSingleInstanceLock() : true
 if (!gotLock) {
   app.quit()
 } else {
-  let isQuitting = false
+  let installingUpdate = false
+  let quit: QuitCoordinator | null = null
 
   registerAppProtocol()
 
@@ -413,25 +418,57 @@ if (!gotLock) {
       (items) => broadcast('evt:inbox', items),
       notifications
     )
-    const updater = new UpdateManager({
-      currentVersion: app.getVersion(),
-      isPackaged: app.isPackaged,
-      autoInstallSupported: process.platform !== 'darwin' || macAutoInstallEnabled,
-      loadUpdater: async () => {
-        const updaterModule = await import('electron-updater')
-        return resolveUpdateClient(updaterModule)
-      },
-      onStateChange: (state) => broadcast('evt:updater', state)
-    })
-
     const tray = new TrayManager(
       () => BrowserWindow.getAllWindows()[0],
       i18n,
       () => {
-        isQuitting = true
+        quit?.markQuitting()
         app.quit()
       }
     )
+    quit = new QuitCoordinator(async () => {
+      downloads.shutdown()
+      integrationTasks.shutdown()
+      follows.stop()
+      tray.destroy()
+      await localRuntime.shutdown()
+    })
+    const updater = new UpdateManager({
+      currentVersion: app.getVersion(),
+      isPackaged: app.isPackaged,
+      autoInstallSupported: process.platform !== 'darwin' || macAutoInstallEnabled,
+      // MacUpdater does not install on quit. true only stages the zip with
+      // Squirrel.Mac after download so Restart can relaunch instead of
+      // closing windows and leaving the process in the dock.
+      autoInstallOnAppQuit: process.platform === 'darwin',
+      loadUpdater: async () => {
+        const updaterModule = await import('electron-updater')
+        return resolveUpdateClient(updaterModule)
+      },
+      prepareInstall: async () => {
+        installingUpdate = true
+        try {
+          await quit?.beginCleanup()
+        } catch (error) {
+          installingUpdate = false
+          throw error
+        }
+      },
+      scheduleInstall: (task) => {
+        setImmediate(() => {
+          task()
+          if (process.platform !== 'darwin') return
+          // Always relaunch if we are still alive: Squirrel may have closed
+          // windows without starting the new process.
+          const timer = setTimeout(() => {
+            app.relaunch()
+            app.exit(0)
+          }, MAC_INSTALL_RELAUNCH_FALLBACK_MS)
+          timer.unref?.()
+        })
+      },
+      onStateChange: (state) => broadcast('evt:updater', state)
+    })
 
     const rebuildMenu = (): void => {
       buildMenu(i18n, navigate)
@@ -568,7 +605,7 @@ if (!gotLock) {
       win.on('ready-to-show', () => win.show())
 
       win.on('close', (event) => {
-        if (isQuitting || !settings.get().closeToTray) return
+        if (quit?.isQuitting() || !settings.get().closeToTray) return
         event.preventDefault()
         win.hide()
         tray.ensure()
@@ -621,7 +658,7 @@ if (!gotLock) {
       // permanently blank window; past the retry bound the user decides.
       let renderFailures = 0
       const recoverRenderer = (reason: string): void => {
-        if (win.isDestroyed() || isQuitting) return
+        if (win.isDestroyed() || quit?.isQuitting()) return
         renderFailures += 1
         console.error(
           `[window] renderer failure (${reason}), recovery ${renderFailures}/${MAX_RENDER_RECOVERIES}`
@@ -701,6 +738,9 @@ if (!gotLock) {
     void auth.init()
 
     app.on('activate', () => {
+      // During update-install the windows are gone on purpose; recreating one
+      // would bring back the old version and cancel the relaunch fallback.
+      if (quit?.isQuitting()) return
       const win = BrowserWindow.getAllWindows()[0]
       if (win) {
         if (win.isMinimized()) win.restore()
@@ -711,25 +751,23 @@ if (!gotLock) {
       }
     })
 
-    let quitCleanupStarted = false
-    let quitCleanupFinished = false
     app.on('before-quit', (event) => {
-      isQuitting = true
-      if (!quitCleanupFinished) event.preventDefault()
-      if (quitCleanupStarted) return
-      quitCleanupStarted = true
-      downloads.shutdown()
-      integrationTasks.shutdown()
-      follows.stop()
-      tray.destroy()
-      void localRuntime.shutdown().finally(() => {
-        quitCleanupFinished = true
+      if (!quit) return
+      quit.markQuitting()
+      if (!quit.canQuit()) event.preventDefault()
+      void quit.beginCleanup().finally(() => {
+        // quitAndInstall / the macOS relaunch fallback owns the exit so we
+        // do not issue a regular quit that skips Squirrel's relaunch.
+        if (installingUpdate) return
         app.quit()
       })
     })
   })
 
   app.on('window-all-closed', () => {
-    if (process.platform !== 'darwin') app.quit()
+    // Installing: Squirrel should relaunch; if it only closed windows, the
+    // fallback timer relaunches. Do not quit here or the new process never starts.
+    if (installingUpdate) return
+    if (process.platform !== 'darwin' || quit?.isQuitting()) app.quit()
   })
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -149,6 +149,7 @@ if (!gotLock) {
   let installingUpdate = false
   let quit: QuitCoordinator | null = null
   let macInstallRelaunchTimer: ReturnType<typeof setTimeout> | null = null
+  let restoreAfterFailedInstall: (() => void) | null = null
 
   const recoverFromFailedInstall = (): void => {
     if (macInstallRelaunchTimer !== null) {
@@ -157,6 +158,7 @@ if (!gotLock) {
     }
     installingUpdate = false
     quit?.reset()
+    restoreAfterFailedInstall?.()
     const win = BrowserWindow.getAllWindows()[0]
     if (win && !win.isDestroyed()) {
       if (win.isMinimized()) win.restore()
@@ -452,6 +454,11 @@ if (!gotLock) {
       tray.destroy()
       await localRuntime.shutdown()
     })
+    restoreAfterFailedInstall = () => {
+      downloads.resumeAfterShutdown()
+      follows.start()
+      if (settings.get().closeToTray) tray.ensure()
+    }
     const updater = new UpdateManager({
       currentVersion: app.getVersion(),
       isPackaged: app.isPackaged,

--- a/apps/desktop/src/main/quit-coordinator.test.ts
+++ b/apps/desktop/src/main/quit-coordinator.test.ts
@@ -58,4 +58,35 @@ describe('QuitCoordinator', () => {
     expect(quit.isQuitting()).toBe(true)
     expect(quit.canQuit()).toBe(false)
   })
+
+  it('retries cleanup after a failed attempt', async () => {
+    let calls = 0
+    const quit = new QuitCoordinator(() => {
+      calls += 1
+      if (calls === 1) throw new Error('boom')
+    })
+
+    await expect(quit.beginCleanup()).rejects.toThrow('boom')
+    await quit.beginCleanup()
+    expect(calls).toBe(2)
+    expect(quit.isQuitting()).toBe(true)
+    expect(quit.canQuit()).toBe(true)
+  })
+
+  it('reset clears quitting so a failed install can be retried', async () => {
+    let calls = 0
+    const quit = new QuitCoordinator(() => {
+      calls += 1
+    })
+
+    await quit.beginCleanup()
+    quit.reset()
+    expect(quit.isQuitting()).toBe(false)
+    expect(quit.canQuit()).toBe(false)
+
+    await quit.beginCleanup()
+    expect(calls).toBe(2)
+    expect(quit.isQuitting()).toBe(true)
+    expect(quit.canQuit()).toBe(true)
+  })
 })

--- a/apps/desktop/src/main/quit-coordinator.test.ts
+++ b/apps/desktop/src/main/quit-coordinator.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { QuitCoordinator } from './quit-coordinator'
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('QuitCoordinator', () => {
+  it('runs cleanup once and then allows quit', async () => {
+    let calls = 0
+    const quit = new QuitCoordinator(() => {
+      calls += 1
+    })
+
+    expect(quit.isQuitting()).toBe(false)
+    expect(quit.canQuit()).toBe(false)
+
+    const first = quit.beginCleanup()
+    const second = quit.beginCleanup()
+    expect(first).toBe(second)
+    expect(quit.isQuitting()).toBe(true)
+
+    await first
+    expect(calls).toBe(1)
+    expect(quit.canQuit()).toBe(true)
+  })
+
+  it('marks quitting immediately even while cleanup is still running', async () => {
+    const gate = deferred()
+    const quit = new QuitCoordinator(() => gate.promise)
+
+    const pending = quit.beginCleanup()
+    expect(quit.isQuitting()).toBe(true)
+    expect(quit.canQuit()).toBe(false)
+
+    gate.resolve()
+    await pending
+    expect(quit.canQuit()).toBe(true)
+  })
+
+  it('still allows quit if cleanup throws so the process cannot get stuck', async () => {
+    const quit = new QuitCoordinator(() => {
+      throw new Error('boom')
+    })
+
+    await expect(quit.beginCleanup()).rejects.toThrow('boom')
+    expect(quit.isQuitting()).toBe(true)
+    expect(quit.canQuit()).toBe(true)
+  })
+
+  it('lets markQuitting flip the flag before cleanup starts', () => {
+    const quit = new QuitCoordinator(() => undefined)
+    quit.markQuitting()
+    expect(quit.isQuitting()).toBe(true)
+    expect(quit.canQuit()).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/quit-coordinator.ts
+++ b/apps/desktop/src/main/quit-coordinator.ts
@@ -1,0 +1,43 @@
+/**
+ * Serializes app teardown so window-close, tray-quit, and updater install share
+ * one "we are leaving" flag and one cleanup pass.
+ *
+ * electron-updater's macOS quitAndInstall closes windows before `before-quit`.
+ * If close-to-tray still intercepts those closes, or if `before-quit`
+ * preventDefault's the Squirrel handshake, the UI vanishes and the process
+ * stays in the dock.
+ */
+export class QuitCoordinator {
+  private quitting = false
+  private cleanupFinished = false
+  private cleanupPromise: Promise<void> | null = null
+  private readonly runCleanup: () => void | Promise<void>
+
+  constructor(runCleanup: () => void | Promise<void>) {
+    this.runCleanup = runCleanup
+  }
+
+  isQuitting(): boolean {
+    return this.quitting
+  }
+
+  /** True once cleanup finished; `before-quit` may proceed without preventDefault. */
+  canQuit(): boolean {
+    return this.cleanupFinished
+  }
+
+  markQuitting(): void {
+    this.quitting = true
+  }
+
+  beginCleanup(): Promise<void> {
+    this.quitting = true
+    if (this.cleanupPromise) return this.cleanupPromise
+    this.cleanupPromise = Promise.resolve()
+      .then(() => this.runCleanup())
+      .finally(() => {
+        this.cleanupFinished = true
+      })
+    return this.cleanupPromise
+  }
+}

--- a/apps/desktop/src/main/quit-coordinator.ts
+++ b/apps/desktop/src/main/quit-coordinator.ts
@@ -30,14 +30,26 @@ export class QuitCoordinator {
     this.quitting = true
   }
 
+  /** Undo a failed update-install attempt so the UI and a later Restart can proceed. */
+  reset(): void {
+    this.quitting = false
+    this.cleanupFinished = false
+    this.cleanupPromise = null
+  }
+
   beginCleanup(): Promise<void> {
     this.quitting = true
     if (this.cleanupPromise) return this.cleanupPromise
-    this.cleanupPromise = Promise.resolve()
+    const attempt = Promise.resolve()
       .then(() => this.runCleanup())
       .finally(() => {
         this.cleanupFinished = true
       })
-    return this.cleanupPromise
+    this.cleanupPromise = attempt
+    // A rejected attempt must not be cached: UpdateManager retries prepareInstall.
+    void attempt.catch(() => {
+      if (this.cleanupPromise === attempt) this.cleanupPromise = null
+    })
+    return attempt
   }
 }

--- a/apps/desktop/src/main/updater.test.ts
+++ b/apps/desktop/src/main/updater.test.ts
@@ -77,6 +77,8 @@ function setup(
   options: {
     packaged?: boolean
     autoInstallSupported?: boolean
+    autoInstallOnAppQuit?: boolean
+    prepareInstall?: () => void | Promise<void>
     client?: FakeUpdateClient
   } = {}
 ): {
@@ -94,6 +96,8 @@ function setup(
     currentVersion: '1.0.0',
     isPackaged: options.packaged ?? true,
     autoInstallSupported: options.autoInstallSupported,
+    autoInstallOnAppQuit: options.autoInstallOnAppQuit,
+    prepareInstall: options.prepareInstall,
     loadUpdater,
     onStateChange: (state) => states.push(state),
     scheduleInstall: (task) => scheduled.push(task),
@@ -211,6 +215,75 @@ describe('UpdateManager', () => {
     expect(client.installCalls).toHaveLength(0)
     scheduled[0]!()
     expect(client.installCalls).toEqual([[false, true]])
+  })
+
+  it('stages the update with Squirrel when autoInstallOnAppQuit is enabled', async () => {
+    const { client, manager } = setup({ autoInstallOnAppQuit: true })
+    client.nextVersion = '1.1.0'
+
+    await manager.checkForUpdates()
+    expect(client.autoInstallOnAppQuit).toBe(true)
+  })
+
+  it('prepares the process for quit before calling quitAndInstall', async () => {
+    const order: string[] = []
+    const { client, manager, scheduled } = setup({
+      prepareInstall: () => {
+        order.push('prepare')
+      }
+    })
+    client.nextVersion = '1.1.0'
+    await manager.checkForUpdates()
+    await manager.downloadUpdate()
+
+    await manager.installUpdate()
+    expect(order).toEqual(['prepare'])
+    expect(client.installCalls).toHaveLength(0)
+    scheduled[0]!()
+    expect(client.installCalls).toEqual([[false, true]])
+  })
+
+  it('waits for async prepareInstall before scheduling quitAndInstall', async () => {
+    const gate = deferred()
+    const { client, manager, scheduled } = setup({
+      prepareInstall: async () => {
+        await gate.promise
+      }
+    })
+    client.nextVersion = '1.1.0'
+    await manager.checkForUpdates()
+    await manager.downloadUpdate()
+
+    const install = manager.installUpdate()
+    await Promise.resolve()
+    expect(scheduled).toHaveLength(0)
+    gate.resolve()
+    await install
+    expect(scheduled).toHaveLength(1)
+  })
+
+  it('fails the install and allows retry if prepareInstall throws', async () => {
+    let shouldFail = true
+    const { client, manager, scheduled } = setup({
+      prepareInstall: () => {
+        if (shouldFail) throw new Error('cleanup failed')
+      }
+    })
+    client.nextVersion = '1.1.0'
+    await manager.checkForUpdates()
+    await manager.downloadUpdate()
+
+    await manager.installUpdate()
+    expect(manager.getState()).toMatchObject({
+      status: 'error',
+      operation: 'install',
+      error: 'unknown'
+    })
+    expect(scheduled).toHaveLength(0)
+
+    shouldFail = false
+    await manager.installUpdate()
+    expect(scheduled).toHaveLength(1)
   })
 
   it('classifies an asynchronous install error and allows retrying the downloaded update', async () => {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -59,8 +59,18 @@ interface UpdateManagerOptions {
   currentVersion: string
   isPackaged: boolean
   autoInstallSupported?: boolean
+  /**
+   * Passed through to electron-updater. Keep false on Windows/Linux so a
+   * normal quit does not spawn the installer. On macOS MacUpdater does not
+   * install on quit — the flag only tells Squirrel.Mac to stage the zip
+   * after download, which quitAndInstall needs to relaunch instead of just
+   * closing windows.
+   */
+  autoInstallOnAppQuit?: boolean
   loadUpdater: () => Promise<UpdateClient>
   onStateChange: (state: AppUpdateState) => void
+  /** Awaited before quitAndInstall so close-to-tray / before-quit can let the process die. */
+  prepareInstall?: () => void | Promise<void>
   scheduleInstall?: (task: () => void) => void
   logger?: Pick<Console, 'warn'>
   /** How long to wait for quitAndInstall to actually quit the app before treating it as failed. */
@@ -106,8 +116,10 @@ export class UpdateManager {
   private readonly currentVersion: string
   private readonly isPackaged: boolean
   private readonly autoInstallSupported: boolean
+  private readonly autoInstallOnAppQuit: boolean
   private readonly loadUpdater: () => Promise<UpdateClient>
   private readonly onStateChange: (state: AppUpdateState) => void
+  private readonly prepareInstall: () => Promise<void>
   private readonly scheduleInstall: (task: () => void) => void
   private readonly logger: Pick<Console, 'warn'>
   private readonly installTimeoutMs: number
@@ -123,8 +135,12 @@ export class UpdateManager {
     this.currentVersion = options.currentVersion
     this.isPackaged = options.isPackaged
     this.autoInstallSupported = options.autoInstallSupported ?? true
+    this.autoInstallOnAppQuit = options.autoInstallOnAppQuit ?? false
     this.loadUpdater = options.loadUpdater
     this.onStateChange = options.onStateChange
+    this.prepareInstall = async () => {
+      await options.prepareInstall?.()
+    }
     this.scheduleInstall = options.scheduleInstall ?? ((task) => setImmediate(task))
     this.logger = options.logger ?? console
     this.installTimeoutMs = options.installTimeoutMs ?? 45_000
@@ -171,15 +187,16 @@ export class UpdateManager {
     this.installScheduled = true
     try {
       const client = await this.getClient()
+      await this.prepareInstall()
       this.scheduleInstall(() => {
         try {
           client.quitAndInstall(false, true)
           // quitAndInstall is expected to quit the app almost immediately, at which
           // point no further JS runs. If we're still alive after this fires, the
           // native install/relaunch handshake silently never completed (observed on
-          // macOS) and the user is left staring at an app that didn't restart.
-          // installScheduled may already be false here if quitAndInstall reported
-          // its failure synchronously (via the client's 'error' event).
+          // macOS) and the host should force a relaunch. installScheduled may
+          // already be false here if quitAndInstall reported its failure
+          // synchronously (via the client's 'error' event).
           if (this.installScheduled) this.armInstallWatchdog()
         } catch (error) {
           this.installScheduled = false
@@ -271,7 +288,7 @@ export class UpdateManager {
       this.clientPromise = this.loadUpdater()
         .then((client) => {
           client.autoDownload = false
-          client.autoInstallOnAppQuit = false
+          client.autoInstallOnAppQuit = this.autoInstallOnAppQuit
           client.allowPrerelease = false
           client.allowDowngrade = false
           client.disableWebInstaller = true

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -78,4 +78,7 @@ manifest and all files it references in the same release; preflight rejects miss
 mismatches.
 
 The application checks only published releases. Update discovery, download, and restart-install are
-separate user actions, and development builds do not load the updater.
+separate user actions, and development builds do not load the updater. On macOS the downloaded zip
+is staged with Squirrel.Mac after download; Restart must quit the process (not only close windows)
+and relaunch so ShipIt can apply the staged update. If the native handshake never relaunches, the
+app relaunches itself.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On macOS, **Restart and install** only closed the window. The process stayed in the Dock (or quit without coming back), so the user had to reopen the app by hand.

Three things stacked:

1. `UpdateManager` always set `autoInstallOnAppQuit = false`. On Windows/Linux that correctly blocks a silent installer-on-quit. On macOS, `MacUpdater` does **not** install on quit — the flag only tells Squirrel.Mac to stage the downloaded zip. Leaving it false meant `quitAndInstall` started the Squirrel fetch at click time and typically just closed windows.
2. Electron's `autoUpdater.quitAndInstall()` closes windows **before** `before-quit`. Close-to-tray could hide the window instead of destroying it, and our async `before-quit` `preventDefault` cancelled Squirrel's quit-and-relaunch.
3. `window-all-closed` never calls `app.quit()` on darwin, so a handshake that only closed windows left a windowless process in the Dock.

## Fix

- Stage the update with Squirrel.Mac after download (`autoInstallOnAppQuit: true` on darwin only).
- Share one `QuitCoordinator` for tray quit, Cmd+Q, and update install. Cleanup (downloads, tray, local runtime) finishes **before** `quitAndInstall`, and `before-quit` no longer blocks once cleanup is done.
- Mark the app as quitting before windows close so close-to-tray cannot intercept the install path. Ignore Dock `activate` while quitting so the old window is not recreated.
- If the native handshake still leaves the process alive, relaunch and `app.exit(0)` after 8s so ShipIt can apply the staged update.

Windows/Linux behavior is unchanged: `autoInstallOnAppQuit` stays false there.

## Testing

- Unit tests for `QuitCoordinator` and the updater `prepareInstall` / `autoInstallOnAppQuit` hooks.
- Could not exercise the real Squirrel.Mac handshake in this Linux environment.

This version must be installed once by hand (or by fully quitting the leftover process). The next update after that should Restart correctly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ae8337b-8e01-46d3-a8db-f0518efe32e0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ae8337b-8e01-46d3-a8db-f0518efe32e0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

